### PR TITLE
Fix ichorCNA PoN generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,25 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.0.2 - [2028-09-13]
+## v1.0.3 - [2024-10-16]
+
+### Bug Fixes
+
+- Fix downloading genomes from iGenomes (#19)
+- Fix a pipeline hang when a panel of normals was built at the same time as an ichorCNA run (#20)
+
+## v1.0.2 - [2024-09-13]
 
 ### Bug Fixes
 
 - Fix CIN signature output file detection.
 
-## v1.0.1 - [2028-09-05]
+## v1.0.1 - [2024-09-05]
 
 ### Bug Fixes
 
 - Bump container version for gistic-cli to fix an off-by-one error in upstream gistic-cli.
 
-## v1.0.0 - [2028-08-08]
+## v1.0.0 - [2024-08-08]
 
 Initial release of dincalcilab/samurai, created with the [nf-core](https://nf-co.re/) template.

--- a/modules/local/ichorcna/create_pon/main.nf
+++ b/modules/local/ichorcna/create_pon/main.nf
@@ -6,7 +6,7 @@ tag "Generate panel of normals"
 container "quay.io/dincalcilab/ichorcna:0.4.0-2ab0be2"
 
 input:
-    path wigfiles
+    path wigfile_list
     path gc_wig
     path map_wig
     path centromere
@@ -32,10 +32,8 @@ def VERSION = '0.3.2' // Version information not provided by tool on CLI
 
 """
 
-echo "${wigfiles.join("\n")}" > PoN_wigfiles.txt
-
 ${ichorcna_script}\\
-    --filelist PoN_wigfiles.txt \\
+    --filelist ${wigfile_list} \\
     --gcWig ${gc_wig} \\
     --mapWig ${map_wig} \\
     ${centro} \\

--- a/modules/local/ichorcna/create_pon/main.nf
+++ b/modules/local/ichorcna/create_pon/main.nf
@@ -32,8 +32,10 @@ def VERSION = '0.3.2' // Version information not provided by tool on CLI
 
 """
 
+echo "${wigfiles.join("\n")}" > PoN_wigfiles.txt
+
 ${ichorcna_script}\\
-    --filelist ${wigfile_list} \\
+    --filelist PoN_wigfiles.txt \\
     --gcWig ${gc_wig} \\
     --mapWig ${map_wig} \\
     ${centro} \\

--- a/modules/local/ichorcna/create_pon/main.nf
+++ b/modules/local/ichorcna/create_pon/main.nf
@@ -32,7 +32,7 @@ def VERSION = '0.3.2' // Version information not provided by tool on CLI
 
 """
 
-echo "${wigfiles.join("\n")}" > PoN_wigfiles.txt
+echo "${wigfile_list.join("\n")}" > PoN_wigfiles.txt
 
 ${ichorcna_script}\\
     --filelist PoN_wigfiles.txt \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -321,7 +321,7 @@ manifest {
     description     = "SAMURAI: Shallow Analysis of Copy nuMber alterations Using a Reproducible And Integrated bioinformatics pipeline"
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '1.0.2'
+    version         = '1.0.3'
     doi             = '10.1101/2024.09.30.615766'
 }
 

--- a/subworkflows/local/build_pon/main.nf
+++ b/subworkflows/local/build_pon/main.nf
@@ -36,16 +36,18 @@ workflow BUILD_PON {
 
                 HMMCOPY_READCOUNTER_PON(ch_bam_for_pon)
                 wigfiles = HMMCOPY_READCOUNTER_PON.out.wig.map {
-                    it ->
-                    it[1]
-                }
+                    meta, wigfile ->
+                    wigfile
+                }.collectFile("wigfiles.txt")
 
                 gc_wig              = Channel.value(params.ichorcna_gc_wig)
                 map_wig             = Channel.value(params.ichorcna_map_wig)
                 reptime_file        = Channel.value(params.ichorcna_reptime_wig)
                 centromere          = Channel.value(params.ichorcna_centromere_file)
 
-                ICHORCNA_GENERATE_PON(wigfiles.collect(),
+
+
+                ICHORCNA_GENERATE_PON(wigfiles,
                                     gc_wig, map_wig, centromere, reptime_file)
 
                 normal_panel = ICHORCNA_GENERATE_PON.out.pon_file

--- a/subworkflows/local/build_pon/main.nf
+++ b/subworkflows/local/build_pon/main.nf
@@ -38,19 +38,17 @@ workflow BUILD_PON {
                 wigfiles = HMMCOPY_READCOUNTER_PON.out.wig.map {
                     meta, wigfile ->
                     wigfile
-                }
+                }.collect()
 
-                gc_wig              = Channel.value(params.ichorcna_gc_wig)
-                map_wig             = Channel.value(params.ichorcna_map_wig)
-                reptime_file        = Channel.value(params.ichorcna_reptime_wig)
-                centromere          = Channel.value(params.ichorcna_centromere_file)
+                // FIXME: ship these with the pipeline
+                // Use files and not values to avoid hangs (#20)
+                gc_wig              = file(params.ichorcna_gc_wig)
+                map_wig             = file(params.ichorcna_map_wig)
+                reptime_file        = file(params.ichorcna_reptime_wig)
+                centromere          = file(params.ichorcna_centromere_file)
 
-                println wigfiles.collect().view()
-                wigfiles2 = wigfiles.collectFile(name: "wigfile.txt", newLine: true)
-
-
-                ICHORCNA_GENERATE_PON(wigfiles2,
-                                    gc_wig, map_wig, centromere, reptime_file)
+                ICHORCNA_GENERATE_PON(wigfiles,
+                                     gc_wig, map_wig, centromere, reptime_file)
 
                 normal_panel = ICHORCNA_GENERATE_PON.out.pon_file
                 ch_versions = ch_versions.mix(ICHORCNA_GENERATE_PON.out.versions)

--- a/subworkflows/local/build_pon/main.nf
+++ b/subworkflows/local/build_pon/main.nf
@@ -38,9 +38,7 @@ workflow BUILD_PON {
                 wigfiles = HMMCOPY_READCOUNTER_PON.out.wig.map {
                     meta, wigfile ->
                     wigfile
-                }
-
-                collected_wigs = wigfiles.collectFile(name: "wigfiles.txt", newLine: true)
+                }.collectFile(name: "wigfiles.txt", newLine: true)
 
                 gc_wig              = Channel.value(params.ichorcna_gc_wig)
                 map_wig             = Channel.value(params.ichorcna_map_wig)

--- a/subworkflows/local/build_pon/main.nf
+++ b/subworkflows/local/build_pon/main.nf
@@ -38,7 +38,9 @@ workflow BUILD_PON {
                 wigfiles = HMMCOPY_READCOUNTER_PON.out.wig.map {
                     meta, wigfile ->
                     wigfile
-                }.collectFile("wigfiles.txt")
+                }
+
+                collected_wigs = wigfiles.collectFile("wigfiles.txt")
 
                 gc_wig              = Channel.value(params.ichorcna_gc_wig)
                 map_wig             = Channel.value(params.ichorcna_map_wig)

--- a/subworkflows/local/build_pon/main.nf
+++ b/subworkflows/local/build_pon/main.nf
@@ -40,7 +40,7 @@ workflow BUILD_PON {
                     wigfile
                 }
 
-                collected_wigs = wigfiles.collectFile("wigfiles.txt")
+                collected_wigs = wigfiles.collectFile(name: "wigfiles.txt", newLine: true)
 
                 gc_wig              = Channel.value(params.ichorcna_gc_wig)
                 map_wig             = Channel.value(params.ichorcna_map_wig)

--- a/subworkflows/local/build_pon/main.nf
+++ b/subworkflows/local/build_pon/main.nf
@@ -38,16 +38,18 @@ workflow BUILD_PON {
                 wigfiles = HMMCOPY_READCOUNTER_PON.out.wig.map {
                     meta, wigfile ->
                     wigfile
-                }.collectFile(name: "wigfiles.txt", newLine: true)
+                }
 
                 gc_wig              = Channel.value(params.ichorcna_gc_wig)
                 map_wig             = Channel.value(params.ichorcna_map_wig)
                 reptime_file        = Channel.value(params.ichorcna_reptime_wig)
                 centromere          = Channel.value(params.ichorcna_centromere_file)
 
+                println wigfiles.collect().view()
+                wigfiles2 = wigfiles.collectFile(name: "wigfile.txt", newLine: true)
 
 
-                ICHORCNA_GENERATE_PON(wigfiles,
+                ICHORCNA_GENERATE_PON(wigfiles2,
                                     gc_wig, map_wig, centromere, reptime_file)
 
                 normal_panel = ICHORCNA_GENERATE_PON.out.pon_file


### PR DESCRIPTION
The process expects file paths to run ichorCNA. The code was instead  sending them as values, causing the pipeline to hang while waiting for  data that never arrived.

Fixes #20.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.

